### PR TITLE
Update FIT_to_CSV_forWin.py

### DIFF
--- a/FIT_to_CSV_forWin.py
+++ b/FIT_to_CSV_forWin.py
@@ -6,7 +6,7 @@ import pytz
 
 allowed_fields = ['timestamp','position_lat','position_long', 'distance',
 'enhanced_altitude', 'altitude','enhanced_speed',
-                 'speed', 'heart_rate','temperature','cadence','fractional_cadence']
+                 'speed', 'heart_rate','temperature','cadence','fractional_cadence''absolute_pressure','cns_load','depth','n2_load','ndl_time','next_stop_depth','next_stop_time','time_to_surface','unknown_123','unknown_124','unknown_127']
 required_fields = ['timestamp']
 
 UTC = pytz.UTC


### PR DESCRIPTION
Added additional 'allowed fields' to include everything that is shown by fitparse from a Garmin Descent Mk2i (Dive Computer).
Tested against a dive file.
The "unknown fields" seem to be (from https://github.com/subsurface/libdc/blob/17bc0faa5157517d90edc0e6353b3d4848324700/src/garmin_parser.c  (see line 817 on))
123, air_time_remaining, UINT32),	// seconds
124, pressure_sac, UINT16),	// 100 * bar/min/pressure
127, ascent_rate, SINT32),	// mm/s (negative is down)